### PR TITLE
Added command to serve a bento in a new VS Code terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,15 +93,7 @@
       },
       {
         "command": "bentoml.serveBentoInTerminal",
-        "title": "BentoML: Serve Bento in new Terminal",
-        "input": [
-          {
-            "type": "promptString",
-            "id": "bentoTag",
-            "description": "Bento Tag",
-            "prompt": "Enter the Bento Tag"
-          }
-        ]
+        "title": "BentoML: Serve Bento in new Terminal"
       },
       {
         "command": "bentoml.refreshModelEntry",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,18 @@
         "title": "BentoML: Install Python Dependencies"
       },
       {
+        "command": "bentoml.serveBentoInTerminal",
+        "title": "BentoML: Serve Bento in new Terminal",
+        "input": [
+          {
+            "type": "promptString",
+            "id": "bentoTag",
+            "description": "Bento Tag",
+            "prompt": "Enter the Bento Tag"
+          }
+        ]
+      },
+      {
         "command": "bentoml.refreshModelEntry",
         "title": "BentoML: Refresh models",
         "icon": "$(refresh)"

--- a/src/common/commands/serve-bento-in-terminal.ts
+++ b/src/common/commands/serve-bento-in-terminal.ts
@@ -1,0 +1,45 @@
+import * as vscode from 'vscode';
+import { getPathToActivePythonInterpreter } from '../python';
+
+/**
+ * Display input boxes to the user and use the inputs to launch a new terminal with a served bento.
+ *
+ * Open an interactive terminal and execute `bentoml serve ...`.
+ */
+export const serveBentoInTerminalCommand = async (): Promise<void> => {
+  const bentoTag: string = (await vscode.window.showInputBox({
+    prompt: 'Enter Bento Tag:',
+    placeHolder: 'e.g. example_service:qmrtzrhchk3ba5wy',
+  })) as string;
+
+  const port: string = (await vscode.window.showInputBox({
+    prompt: 'Enter Server Port:',
+    placeHolder: '3001',
+    value: '3001', // Set a default value for port
+  })) as string;
+
+  // Validate and process the provided values
+  // ... (Perform checks for valid Bento Tag and port number)
+
+  serveBentoInTerminal(bentoTag, port);
+};
+
+/**
+ * Open an interactive terminal and execute `bentoml serve ...`.
+ *
+ * @param bentoTag identifier of the form <name>:<version>
+ * @param port http port
+ */
+export const serveBentoInTerminal = async (bentoTag: string, port: string | number): Promise<void> => {
+  const interpreterFpath: string = (await getPathToActivePythonInterpreter()) as string;
+
+  const [bentoName, bentoVersion] = bentoTag.split(':');
+  const terminalDisplayName = `BentoML Serve: ${bentoVersion}`;
+  const terminal = vscode.window.createTerminal(terminalDisplayName);
+
+  // navigate the user to the terminal / set the terminal as active
+  terminal.show();
+
+  // execute the command
+  terminal.sendText(`${interpreterFpath} -m bentoml serve ${bentoTag} --port ${port}`);
+};


### PR DESCRIPTION
https://github.com/mlops-club/vscode-bentoml/assets/32227767/c610cf85-8bc2-4706-b68a-29c7105586c1

I couldn't think of a good test for either of the functions I wrote. UI tests are hard. We probably should execute some and we'll need to put some thought into how to do that. I believe we do run a "virtual headless browser" (xfvb) in our GitHub Actions pipeline, so in theory we can do this.