### PR TITLE
Error handling for loading bentos and models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "bentoml",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bentoml",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@vscode/test-electron": "^2.3.9",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1.0"
       },
@@ -20,7 +21,6 @@
         "@types/vscode": "^1.83.0",
         "@typescript-eslint/eslint-plugin": "^6.9.0",
         "@typescript-eslint/parser": "^6.9.0",
-        "@vscode/test-electron": "^2.3.6",
         "c8": "^8.0.1",
         "eslint": "^8.52.0",
         "glob": "^10.3.10",
@@ -310,7 +310,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -601,10 +600,9 @@
       "dev": true
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.6.tgz",
-      "integrity": "sha512-M31xGH0RgqNU6CZ4/9g39oUMJ99nLzfjA+4UbtIQ6TcXQ6+2qkjOOxedmPBDDCg26/3Al5ubjY80hIoaMwKYSw==",
-      "dev": true,
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.9.tgz",
+      "integrity": "sha512-z3eiChaCQXMqBnk2aHHSEkobmC2VRalFQN0ApOAtydL172zXGxTwGrRtviT5HnUB+Q+G3vtEYFtuQkYqBzYgMA==",
       "dependencies": {
         "http-proxy-agent": "^4.0.1",
         "https-proxy-agent": "^5.0.0",
@@ -851,7 +849,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -1440,8 +1437,7 @@
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1489,7 +1485,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2302,7 +2297,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "dev": true,
       "dependencies": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -2316,7 +2310,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -2337,8 +2330,7 @@
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "dev": true
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -2397,8 +2389,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/interpret": {
       "version": "3.1.1",
@@ -2517,8 +2508,7 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2668,7 +2658,6 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-      "dev": true,
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -2720,7 +2709,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
       "dependencies": {
         "immediate": "~3.0.5"
       }
@@ -3046,8 +3034,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -3211,8 +3198,7 @@
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -3442,8 +3428,7 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -3514,7 +3499,6 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3676,8 +3660,7 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -3701,7 +3684,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3716,7 +3698,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3751,8 +3732,7 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
@@ -3860,7 +3840,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -4294,8 +4273,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.3",
@@ -4744,8 +4722,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bentoml",
   "publisher": "mlops-club",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "displayName": "BentoML",
   "icon": "src/resources/bentoml-logo.png",
   "author": {
@@ -223,7 +223,7 @@
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "lint": "eslint src --ext ts --fix",
     "format": "prettier --write ./",
-    "test": "mv .vscode-test/user-data/1. .vscode-test/user-data/1.84-main.sock; c8 node ./out/test/runTest.js",
+    "test": "c8 node ./out/test/runTest.js",
     "clean": "bash run.sh clean",
     "install-python-deps": "pip install bentoml",
     "serve-coverage-report": "python -m http.server --directory coverage/lcov-report/ 80"
@@ -240,7 +240,6 @@
     "@types/vscode": "^1.83.0",
     "@typescript-eslint/eslint-plugin": "^6.9.0",
     "@typescript-eslint/parser": "^6.9.0",
-    "@vscode/test-electron": "^2.3.6",
     "c8": "^8.0.1",
     "eslint": "^8.52.0",
     "glob": "^10.3.10",
@@ -254,6 +253,7 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
+    "@vscode/test-electron": "^2.3.9",
     "fs-extra": "^11.1.1",
     "js-yaml": "^4.1.0"
   }

--- a/src/common/bentoml/cli-client.ts
+++ b/src/common/bentoml/cli-client.ts
@@ -1,52 +1,112 @@
+import * as vscode from 'vscode';
+import * as consts from '../constants';
 import { Model, SimpleModel, Bento } from './models';
 import { runShellCommand } from '../shell';
 import { tryGetPathToActivePythonInterpreter } from '../python';
-import { traceInfo } from '../logging';
+import { traceVerbose } from '../logging';
 
-export async function listModels() {
+export async function listModels(): Promise<SimpleModel[]> {
   const interpreterFpath = (await tryGetPathToActivePythonInterpreter()) as string;
-  const response = await runShellCommand(interpreterFpath, ['-m', 'bentoml', 'models', 'list', '--output', 'json']);
-  traceInfo(`getModels() response: ${response.logs}`);
-  return JSON.parse(response.logs) as SimpleModel[];
+  const response = await tryRunShellCommand(interpreterFpath, ['-m', 'bentoml', 'models', 'list', '--output', 'json']);
+  traceVerbose(`listModels() response: ${response}`);
+  try {
+    const models = tryParseJsonArrayFromString(response.logs) as SimpleModel[];
+    return models;
+  } catch (error) {
+    vscode.window.showErrorMessage(
+      `[${consts.EXTENSION_NAME}] Failed to list models\n\nError parsing JSON array: ${error}`
+    );
+    throw error;
+  }
 }
 
-export async function listBentos() {
+export async function listBentos(): Promise<Bento[]> {
   const interpreterFpath = (await tryGetPathToActivePythonInterpreter()) as string;
-  const response = await runShellCommand(interpreterFpath, ['-m', 'bentoml', 'list', '--output', 'json']);
-  traceInfo(`getBentos() response: ${response.logs}`);
-  return JSON.parse(response.logs) as Bento[];
+  const response = await tryRunShellCommand(interpreterFpath, ['-m', 'bentoml', 'list', '--output', 'json']);
+  traceVerbose(`listBentos() response: ${response}`);
+  try {
+    const bentos = tryParseJsonArrayFromString(response.logs) as Bento[];
+    return bentos;
+  } catch (error) {
+    vscode.window.showErrorMessage(
+      `[${consts.EXTENSION_NAME}] Failed to list Bentos\n\nError parsing JSON array: ${error}`
+    );
+    throw error;
+  }
 }
 
-export async function getBentoInfo(tag: string) {
+export async function getBentoInfo(tag: string): Promise<string> {
   const interpreterFpath = (await tryGetPathToActivePythonInterpreter()) as string;
-  const response = await runShellCommand(interpreterFpath, ['-m', 'bentoml', 'get', tag]);
-  traceInfo(`showBentos() response: ${response.logs}`);
+  const response = await tryRunShellCommand(interpreterFpath, ['-m', 'bentoml', 'get', tag]);
+  traceVerbose(`getBentoInfo() response: ${response}`);
   return response.logs;
 }
 
-export async function getModelInfo(tag: string) {
+export async function getModelInfo(tag: string): Promise<string> {
   const interpreterFpath = (await tryGetPathToActivePythonInterpreter()) as string;
-  const response = await runShellCommand(interpreterFpath, ['-m', 'bentoml', 'models', 'get', tag]);
-  traceInfo(`showBentos() response: ${response.logs}`);
+  const response = await tryRunShellCommand(interpreterFpath, ['-m', 'bentoml', 'models', 'get', tag]);
+  traceVerbose(`getModelInfo() response: ${response}`);
   return response.logs;
 }
 
-export async function deleteModel(object: SimpleModel) {
+export async function deleteModel(object: SimpleModel): Promise<string> {
   const interpreterFpath = (await tryGetPathToActivePythonInterpreter()) as string;
-  const response = await runShellCommand(interpreterFpath, ['-m', 'bentoml', 'models', 'delete', object.tag, '-y']);
-  traceInfo(response.logs);
+  const response = await tryRunShellCommand(interpreterFpath, ['-m', 'bentoml', 'models', 'delete', object.tag, '-y']);
+  traceVerbose(response);
   return response.logs;
 }
 
-export async function deleteBento(object: Bento) {
+export async function deleteBento(object: Bento): Promise<string> {
   const interpreterFpath = (await tryGetPathToActivePythonInterpreter()) as string;
-  const response = await runShellCommand(interpreterFpath, ['-m', 'bentoml', 'delete', object.tag, '-y']);
-  traceInfo(response.logs);
+  const response = await tryRunShellCommand(interpreterFpath, ['-m', 'bentoml', 'delete', object.tag, '-y']);
+  traceVerbose(response);
   return response.logs;
 }
 
+// TODO: this is a long-running, potentially immortal process. It may be a problem that it uses `await`
+// before runShellCommand. The user should have more visibility and control over the ability immortal processes.
+// For example, running this consumes CPU and binds a port, making the port unusable for other services.
+// See the alternative function in serve-bento-in-terminal.ts for a better approach.
 export async function serve(bentoDirectory: string): Promise<string> {
   const interpreterFpath = (await tryGetPathToActivePythonInterpreter()) as string;
-  const response = await runShellCommand(interpreterFpath, ['-m', 'bentoml', 'serve', bentoDirectory]);
+  const response = await tryRunShellCommand(interpreterFpath, ['-m', 'bentoml', 'serve', bentoDirectory]);
   return response.logs;
 }
+
+export const tryRunShellCommand = async (
+  interpreterFpath: string,
+  args: string[]
+): Promise<{
+  logs: string;
+  exitCode: number;
+}> => {
+  const response = await runShellCommand(interpreterFpath, args);
+  if (response.exitCode !== 0) {
+    vscode.window.showErrorMessage(
+      `[${consts.EXTENSION_NAME}] Command failed with exit code ${response.exitCode}:\n\n${response.logs}`
+    );
+    throw new Error(`Command failed with exit code ${response.exitCode}: ${response.logs}`);
+  }
+  return response;
+};
+
+/**
+ * Return the list of missing packages from the provided list of packages or raise an error
+ * if no such substring exists.
+ *
+ * Why? Sometimes `bentoml ... --output json` commands return additional messages besides the expected
+ * JSON.
+ *
+ * E.g. `bentoml list` returned `Deprecated build option: 'docker.env' is used, please use 'envs' instead. [... the array]`.
+ * This function is resilient to strings with additional messages.
+ *
+ * @param stringWithJsonArraySubstring string that possibly contains a substring that is a JSON array
+ * @returns array parsed from the JSON array substring
+ */
+export const tryParseJsonArrayFromString = (stringWithJsonArraySubstring: string): any[] => {
+  const match = stringWithJsonArraySubstring.match(/\[.*\]/s);
+  if (!match) {
+    throw new Error(`No JSON array found in the string: ${stringWithJsonArraySubstring}`);
+  }
+  return JSON.parse(match[0]);
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -201,10 +201,16 @@ export async function activate(context: vscode.ExtensionContext) {
   // notify the user that the extension activated successfully
   vscode.window.showInformationMessage(`[${consts.EXTENSION_NAME}] extension loaded!`);
 
-  // Perform initial load of bentoml models and bentos to display in the sidebar, TODO this is hacky/brittle
-  // setTimeout(async () => {
-  //   await clearmlSessionsTreeProvider.refresh();
-  // }, 3000);
+  // Perform initial load of bentoml models and bentos to display in the sidebar
+  // TODO: this is hacky/brittle because it waits 3 seconds in hopes that the extension will have
+  // fully loaded before this logic is run.
+  setTimeout(async () => {
+    await Promise.all([
+      bentoMlBentosTreeProvider.refresh(),
+      bentoMlModelsTreeProvider.refresh(),
+      bentoMlServeTreeDataProvider.refresh(),
+    ]);
+  }, 3000);
 }
 
 // This method is called when your extension is deactivated

--- a/src/test/suite/common/bentoml/cli-client.test.ts
+++ b/src/test/suite/common/bentoml/cli-client.test.ts
@@ -1,0 +1,36 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { tryParseJsonArrayFromString } from '../../../../common/bentoml/cli-client';
+import { describe, it } from 'mocha';
+
+const MOCK_BENTOML_LIST_OUTPUT_JSON = [
+  {
+    tag: 'linear_regression:gy36t3ximowm45wy',
+    size: '16.14 KiB',
+    model_size: '941.00 B',
+    creation_time: '2024-03-22 09:45:39',
+  },
+  {
+    tag: 'bentoml-poc:1836',
+    size: '94.35 KiB',
+    model_size: '11.06 KiB',
+    creation_time: '2024-03-12 18:21:08',
+  },
+];
+
+const MOCK_BENTOML_LIST_OUTPUT: string = `
+Deprecated build option: 'docker.env' is used, please use 'envs' instead.
+Deprecated build option: 'docker.env' is used, please use 'envs' instead.
+${JSON.stringify(MOCK_BENTOML_LIST_OUTPUT_JSON)}`;
+
+describe('tryParseJsonArrayFromString', () => {
+  it('should parse JSON array substring from a string', () => {
+    const result = tryParseJsonArrayFromString(MOCK_BENTOML_LIST_OUTPUT);
+    assert.deepStrictEqual(result, MOCK_BENTOML_LIST_OUTPUT_JSON);
+  });
+
+  it('should throw an error if the input string does not contain a JSON array substring', () => {
+    const inputString = 'This is a regular string without any JSON array substring';
+    assert.throws(() => tryParseJsonArrayFromString(inputString));
+  });
+});


### PR DESCRIPTION
- Sidebar now populates on extension load; added more error handling to `bentoml/cli-client`
- Added first ever tests to the repo

The bentos were failing to load with version `bentoml==1.2.5`. I added some logic to how the `bentoml ... --output json` is parsed to make it more resilient to warning messages showing up in the logs.

The tests can be step debugged using this launch configuration
<img width="480" alt="image" src="https://github.com/mlops-club/vscode-bentoml/assets/32227767/2eb905f9-3c89-4e7e-8ab6-1c5567767f6b">

Or run them with `npm run test` or `npm test`

<img width="861" alt="image" src="https://github.com/mlops-club/vscode-bentoml/assets/32227767/4d2bc89c-e11d-41c9-8eab-2ec33a90bfb0">
